### PR TITLE
Jaw create new category

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -1,7 +1,7 @@
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import urlparse, parse_qs
 import json
-from views import create_user, login_user, get_all_posts, get_single_post, get_all_categories, get_all_tags
+from views import create_user,create_new_category,login_user, get_all_posts, get_single_post, get_all_categories, get_all_tags
 
 
 
@@ -100,19 +100,45 @@ class HandleRequests(BaseHTTPRequestHandler):
 
 
     def do_POST(self):
-        """Make a post request to the server"""
-        self._set_headers(201)
         content_len = int(self.headers.get('content-length', 0))
-        post_body = json.loads(self.rfile.read(content_len))
-        response = ''
+        post_body = self.rfile.read(content_len)
+        
+        # convert JSON string to a python dictionary
+        post_body = json.loads(post_body)
+
+        success = False
+
+        #parse the URL
         resource, _ = self.parse_url()
 
-        if resource == 'login':
-            response = login_user(post_body)
-        if resource == 'register':
-            response = create_user(post_body)
+        #initialize new
+        new_category = None
+        new_login = None
+        new_user = None
 
-        self.wfile.write(response.encode())
+        if resource == 'categories':
+            new_category = create_new_category(post_body)
+            success = True
+
+        if resource == 'login':
+            new_login = login_user(post_body)
+            success = True
+
+        if resource == 'register':
+            new_user = create_user(post_body)
+            success = True
+
+        if success:
+            self._set_headers(201)
+                        # Encode the new animal and send in response
+            self.wfile.write(json.dumps(new_category).encode())
+            self.wfile.write(json.dumps(new_login).encode())
+            self.wfile.write(json.dumps(new_user).encode())
+        else:
+            self._set_headers(404)
+            error = ""
+            self.wfile.write(json.dumps(error).encode())
+
 
     def do_PUT(self):
         """Handles PUT requests to the server"""

--- a/request_handler.py
+++ b/request_handler.py
@@ -100,45 +100,22 @@ class HandleRequests(BaseHTTPRequestHandler):
 
 
     def do_POST(self):
+        """Make a post request to the server"""
+        self._set_headers(201)
         content_len = int(self.headers.get('content-length', 0))
-        post_body = self.rfile.read(content_len)
-        
-        # convert JSON string to a python dictionary
-        post_body = json.loads(post_body)
-
-        success = False
-
-        #parse the URL
+        post_body = json.loads(self.rfile.read(content_len))
+        response = ''
         resource, _ = self.parse_url()
 
-        #initialize new
-        new_category = None
-        new_login = None
-        new_user = None
-
-        if resource == 'categories':
-            new_category = create_new_category(post_body)
-            success = True
-
         if resource == 'login':
-            new_login = login_user(post_body)
-            success = True
-
+            response = login_user(post_body)
+            self.wfile.write(response.encode())
         if resource == 'register':
-            new_user = create_user(post_body)
-            success = True
-
-        if success:
-            self._set_headers(201)
-                        # Encode the new animal and send in response
-            self.wfile.write(json.dumps(new_category).encode())
-            self.wfile.write(json.dumps(new_login).encode())
-            self.wfile.write(json.dumps(new_user).encode())
-        else:
-            self._set_headers(404)
-            error = ""
-            self.wfile.write(json.dumps(error).encode())
-
+            response = create_user(post_body)
+            self.wfile.write(response.encode())
+        if resource == 'categories':
+            response = create_new_category(post_body)
+            self.wfile.write(json.dumps(response).encode())
 
     def do_PUT(self):
         """Handles PUT requests to the server"""

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,4 +1,4 @@
 from .user_requests import login_user, create_user
 from .post_requests import get_all_posts, get_single_post
-from .category_requests import get_all_categories
+from .category_requests import get_all_categories,create_new_category
 from .tag_requests import get_all_tags

--- a/views/category_requests.py
+++ b/views/category_requests.py
@@ -37,4 +37,28 @@ def get_all_categories():
             categories.append(category.__dict__)
         
         return categories
-        
+
+
+def create_new_category(new_category):
+    with sqlite3.connect("./db.sqlite3") as conn:
+        db_cursor = conn.cursor()
+
+        db_cursor.execute("""
+        INSERT INTO `Categories`
+            (label)
+        VALUES
+            (?);
+        """,(new_category['label'],))
+
+        # The `lastrowid` property on the cursor will return
+        # the primary key of the last thing that got added to
+        # the database.
+        id = db_cursor.lastrowid
+
+        # Add the `id` property to the animal dictionary that
+        # was sent by the client so that the client sees the
+        # primary key in the response.
+        new_category['id'] = id
+
+
+    return new_category


### PR DESCRIPTION
After going a down wormhole and trying to be extra, I realized my previous push caused login and register to no longer work on the client. As a group we decided on a simple modification to the request handler def POST method. We've got a create-a-new-category function in the category requests, and its also invoked on the request handler. When you view this, make sure the login and register pages work on your client, AND postman for categories before approving!!! 